### PR TITLE
Add Breaks / Replaces for releases before gz

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -29,6 +29,8 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Breaks: libignition-launch6 (<< 5.999.999+nightly+git20220630+2rcec9c00a42bbd412815a3c9d64a3ce9b7dfd186d-2)
+Replaces: libignition-launch6 (<< 5.999.999+nightly+git20220630+2rcec9c00a42bbd412815a3c9d64a3ce9b7dfd186d-2)
 Multi-Arch: same
 Description: Gazebo Launch Library - Launch libraries
  Gazebo Launch, a component of Gazebo, provides a command line
@@ -55,6 +57,8 @@ Depends: libignition-cmake3-dev,
          libgz-launch6 (= ${binary:Version}),
          ${shlibs:Depends},
          ${misc:Depends}
+Breaks: libignition-launch6-dev (<< 5.999.999+nightly+git20220630+2rcec9c00a42bbd412815a3c9d64a3ce9b7dfd186d-2)
+Replaces: libignition-launch6-dev (<< 5.999.999+nightly+git20220630+2rcec9c00a42bbd412815a3c9d64a3ce9b7dfd186d-2)
 Multi-Arch: same
 Description: Gazebo Launch Library - Development files
  Gazebo Launch, a component of Gazebo, provides a command line


### PR DESCRIPTION
* Part of https://github.com/gazebo-tooling/release-tools/issues/736
* Follow up to https://github.com/gazebo-release/gz-launch6-release/pull/10

These make sure that a system with releases before #10 installed can be properly upgraded.

Test build: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-launch6-debbuilder&build=468)](https://build.osrfoundation.org/job/ign-launch6-debbuilder/468/)