### PR TITLE
Install bash completion, move CLI scripts to non-dev package

### DIFF
--- a/focal/debian/gz-launch6-cli.install
+++ b/focal/debian/gz-launch6-cli.install
@@ -1,0 +1,1 @@
+../../ubuntu/debian/gz-launch6-cli.install

--- a/jammy/gz-launch6-cli.install
+++ b/jammy/gz-launch6-cli.install
@@ -1,0 +1,1 @@
+../../ubuntu/debian/gz-launch6-cli.install

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -29,6 +29,7 @@ Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Suggests: gz-launch6-cli
 Breaks: libignition-launch6 (<< 5.999.999+nightly+git20220630+2rcec9c00a42bbd412815a3c9d64a3ce9b7dfd186d-2)
 Replaces: libignition-launch6 (<< 5.999.999+nightly+git20220630+2rcec9c00a42bbd412815a3c9d64a3ce9b7dfd186d-2)
 Multi-Arch: same
@@ -37,6 +38,18 @@ Description: Gazebo Launch Library - Launch libraries
  interface to run and manager application and plugins.
  .
  Package contains the Gazebo launch libraries
+
+Package: gz-launch6-cli
+Architecture: any
+Depends: libgz-launch6 (= ${binary:Version}),
+         ${shlibs:Depends},
+         ${misc:Depends}
+Multi-Arch: no
+Description: Gazebo Launch Library - CLI
+ Gazebo Launch, a component of Gazebo, provides a command line
+ interface to run and manager application and plugins.
+ .
+ Package contains the CLI
 
 Package: libgz-launch6-dev
 Architecture: any
@@ -68,6 +81,14 @@ Description: Gazebo Launch Library - Development files
 
 Package: libignition-launch6
 Depends: libgz-launch6, ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: oldlibs
+Description: transitional package
+ This is a transitional package. It can safely be removed.
+
+Package: ignition-launch6-cli
+Depends: gz-launch6-cli, ${misc:Depends}
 Architecture: all
 Priority: optional
 Section: oldlibs

--- a/ubuntu/debian/gz-launch6-cli.install
+++ b/ubuntu/debian/gz-launch6-cli.install
@@ -1,0 +1,5 @@
+usr/lib/ruby/*
+usr/share/gz/*.yaml
+usr/share/gz/*/configs/*
+usr/share/gz/*completion*/*
+

--- a/ubuntu/debian/libgz-launch-dev.install
+++ b/ubuntu/debian/libgz-launch-dev.install
@@ -2,6 +2,4 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/*-launch*/*
-usr/lib/*/*/launch*/*
-usr/share/gz/*
-usr/lib/ruby/*
+usr/share/gz/*-launch*/*.tag.xml

--- a/ubuntu/debian/libgz-launch.install
+++ b/ubuntu/debian/libgz-launch.install
@@ -1,2 +1,7 @@
 usr/lib/*/*.so.*
 usr/lib/*/*-launch-*/plugins/*.so
+usr/lib/*/*/launch*/*
+usr/lib/ruby/*
+usr/share/gz/*.yaml
+usr/share/gz/*/configs/*
+usr/share/gz/*completion*/*

--- a/ubuntu/debian/libgz-launch.install
+++ b/ubuntu/debian/libgz-launch.install
@@ -1,7 +1,3 @@
 usr/lib/*/*.so.*
 usr/lib/*/*-launch-*/plugins/*.so
 usr/lib/*/*/launch*/*
-usr/lib/ruby/*
-usr/share/gz/*.yaml
-usr/share/gz/*/configs/*
-usr/share/gz/*completion*/*


### PR DESCRIPTION
* Part of
    * https://github.com/gazebo-tooling/release-tools/issues/529
    * https://github.com/gazebosim/gz-tools/issues/1
    
SImilar to: https://github.com/gazebo-release/gz-launch2-release/pull/10

However, we should probably be installing the CLI executable into `/usr/libexec`. Since we're only building for `amd64`, we can do probably do a rename in the `.install` file in this repo, but it would be better to fix it in the source package. /cc @j-rivero .

Focal build: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-launch6-debbuilder&build=599)](https://build.osrfoundation.org/job/gz-launch6-debbuilder/599/)