### PR TITLE
Remove extra dangling symlink

### DIFF
--- a/jammy/gz-launch6-cli.install
+++ b/jammy/gz-launch6-cli.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/gz-launch6-cli.install


### PR DESCRIPTION
That wasn't pointing to anything, causing errors

```
+ cp -a --dereference /tmp/gz-launch6-release/jammy/debian /tmp/gz-launch6-release/jammy/gz-launch6-cli.install .
cp: cannot stat '/tmp/gz-launch6-release/jammy/gz-launch6-cli.install': No such file or directory
```